### PR TITLE
Improve URL extraction from text

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -2,6 +2,8 @@ import aiohttp
 import re
 from lxml import html
 
+from urlextract import URLExtract
+
 print("Reloading")
 
 async def get_title(bot, target, source, url):
@@ -20,12 +22,17 @@ async def get_title(bot, target, source, url):
     return title
 
 def find_urls(message):
-    matches = re.findall(r'\bhttps?://[^ \t]+\b', message)
+    extractor = URLExtract()
+    matches = extractor.find_urls(message)
 
     tidied_matches = []
     for match in matches:
         if match.endswith(')') or match.endswith(','):
             match = match[:-1]
+
+        if not match.startswith('http'):
+            match = 'http://' + match
+
         tidied_matches.append(match)
 
     return tidied_matches

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ lxml
 git+https://github.com/marksteward/pydle#egg=pydle
 pytz
 pyyaml
+urlextract==0.8.3


### PR DESCRIPTION
This switches to using urlextract, which searches for URLs using the public suffix list, which means we can match urls missing a http(s):// prefix.